### PR TITLE
Dakr/improve heartbeats

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ repositories {
 }
 
 group = 'estar'
-version = '1.6.1-ESTAR'
+version = '1.6.2-ESTAR'
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 

--- a/src/main/java/org/java_websocket/SocketChannelIOHelper.java
+++ b/src/main/java/org/java_websocket/SocketChannelIOHelper.java
@@ -97,9 +97,7 @@ public class SocketChannelIOHelper {
     } else {
       int written = 0;
       do {
-        int startPosition = buffer.position();
-        sockchannel.write(buffer);
-        written += buffer.position() - startPosition;
+        written += sockchannel.write(buffer);
         if (buffer.remaining() > 0) {
           return false;
         } else {

--- a/src/main/java/org/java_websocket/WebSocketImpl.java
+++ b/src/main/java/org/java_websocket/WebSocketImpl.java
@@ -119,7 +119,7 @@ public class WebSocketImpl implements WebSocket {
   /**
    * When true no further frames may be submitted to be sent
    */
-  private boolean flushandclosestate = false;
+  private volatile boolean flushandclosestate = false;
 
   /**
    * The current state of the connection

--- a/src/main/java/org/java_websocket/drafts/Draft_6455.java
+++ b/src/main/java/org/java_websocket/drafts/Draft_6455.java
@@ -892,13 +892,13 @@ public class Draft_6455 extends Draft {
   @Override
   public void processFrame(WebSocketImpl webSocketImpl, Framedata frame)
       throws InvalidDataException {
+    webSocketImpl.updateLastPong();
     Opcode curop = frame.getOpcode();
     if (curop == Opcode.CLOSING) {
       processFrameClosing(webSocketImpl, frame);
     } else if (curop == Opcode.PING) {
       webSocketImpl.getWebSocketListener().onWebsocketPing(webSocketImpl, frame);
     } else if (curop == Opcode.PONG) {
-      webSocketImpl.updateLastPong();
       webSocketImpl.getWebSocketListener().onWebsocketPong(webSocketImpl, frame);
     } else if (!frame.isFin() || curop == Opcode.CONTINUOUS) {
       processFrameContinuousAndNonFin(webSocketImpl, frame, curop);

--- a/src/main/java/org/java_websocket/server/WebSocketServer.java
+++ b/src/main/java/org/java_websocket/server/WebSocketServer.java
@@ -130,6 +130,8 @@ public abstract class WebSocketServer extends AbstractWebSocket implements Runna
    */
   private int maxPendingConnections = -1;
 
+  private int maxWriteBatchSizeInBytes = 0;
+
   /**
    * Creates a WebSocketServer that will attempt to listen on port <var>WebSocketImpl.DEFAULT_PORT</var>.
    *
@@ -399,6 +401,10 @@ public abstract class WebSocketServer extends AbstractWebSocket implements Runna
     return maxPendingConnections;
   }
 
+  public void setMaxWriteBatchSizeInBytes(int bytes) {
+    this.maxWriteBatchSizeInBytes = bytes;
+  }
+
   // Runnable IMPLEMENTATION /////////////////////////////////////////////////
   public void run() {
     if (!doEnsureSingleThread()) {
@@ -586,7 +592,7 @@ public abstract class WebSocketServer extends AbstractWebSocket implements Runna
   private void doWrite(SelectionKey key) throws WrappedIOException {
     WebSocketImpl conn = (WebSocketImpl) key.attachment();
     try {
-      if (SocketChannelIOHelper.batch(conn, conn.getChannel()) && key.isValid()) {
+      if (SocketChannelIOHelper.batch(conn, conn.getChannel(), maxWriteBatchSizeInBytes) && key.isValid()) {
         key.interestOps(SelectionKey.OP_READ);
       }
     } catch (IOException e) {

--- a/src/test/java/org/java_websocket/performance/SlowConsumerTest.java
+++ b/src/test/java/org/java_websocket/performance/SlowConsumerTest.java
@@ -1,0 +1,161 @@
+package org.java_websocket.performance;
+
+import org.java_websocket.WebSocket;
+import org.java_websocket.client.WebSocketClient;
+import org.java_websocket.handshake.ClientHandshake;
+import org.java_websocket.handshake.ServerHandshake;
+import org.java_websocket.server.WebSocketServer;
+import org.java_websocket.util.SocketUtil;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Test improved ping/pongs for slow consumers.
+ */
+public class SlowConsumerTest {
+
+    private static final Logger log = LoggerFactory.getLogger(SlowConsumerTest.class);
+
+    @Test
+    public void testClientStableClientConnectionForSlowConsumer() throws Exception {
+        final CountDownLatch countServerStart = new CountDownLatch(1);
+        int port = SocketUtil.getAvailablePort();
+
+        AtomicInteger disconnectCounter = new AtomicInteger(0);
+
+        TestServer server = new TestServer(new InetSocketAddress(port), countServerStart, disconnectCounter);
+        server.setConnectionLostTimeout(2);
+        server.start();
+        countServerStart.await(10, TimeUnit.SECONDS);
+
+        URI uri = new URI("ws://localhost:" + port);
+
+        CountDownLatch countClientConnectionDownLatch = new CountDownLatch(1);
+        CountDownLatch countReceivedMessagesDownLatch = new CountDownLatch(10);
+        WebSocketClient client = new TestClient(uri,
+                countClientConnectionDownLatch,
+                countReceivedMessagesDownLatch,
+                disconnectCounter);
+        client.setConnectionLostTimeout(2);
+        client.connectBlocking();
+        countClientConnectionDownLatch.await(10, TimeUnit.SECONDS);
+
+        // send 10 messages in burst
+        server.startSending();
+
+        countReceivedMessagesDownLatch.await(15, TimeUnit.SECONDS);
+        Assertions.assertEquals(0, disconnectCounter.get(), "Server/Client disconnected.");
+    }
+
+
+    private static class TestServer extends  WebSocketServer {
+
+        private final CountDownLatch countServerStart;
+        private final AtomicInteger disconnectCounter;
+
+        private WebSocket clientConnection;
+
+        public TestServer(InetSocketAddress address, CountDownLatch countServerStart, AtomicInteger disconnectCounter) {
+            super(address);
+            this.countServerStart = countServerStart;
+            this.disconnectCounter = disconnectCounter;
+        }
+
+        @Override
+        public void onOpen(WebSocket conn, ClientHandshake handshake) {
+            clientConnection = conn;
+        }
+
+        @Override
+        public void onClose(WebSocket conn, int code, String reason, boolean remote) {
+            log.error("Connection lost, code: {}, reason: {}, remote: {}", code, reason, remote);
+            disconnectCounter.incrementAndGet();
+        }
+
+        @Override
+        public void onMessage(WebSocket conn, ByteBuffer message) {
+        }
+
+        @Override
+        public void onMessage(WebSocket conn, String message) {
+        }
+
+        @Override
+        public void onError(WebSocket conn, Exception ex) {
+            log.error("Connection lost on error", ex);
+            disconnectCounter.incrementAndGet();
+        }
+
+        @Override
+        public void onStart() {
+            countServerStart.countDown();
+        }
+
+        // burst send 10 messages
+        public void startSending() {
+            if (clientConnection == null)
+                throw new RuntimeException("No client connected");
+
+            byte[] msg = new byte[1];
+            for (int i = 0; i < 10; i++) {
+                clientConnection.send(msg);
+            }
+        }
+
+    }
+
+    static class TestClient extends WebSocketClient {
+        private final CountDownLatch onOpenLach;
+        private final CountDownLatch messagesReceivedLatch;
+        private final AtomicInteger disconnectCounter;
+
+        public TestClient(URI uri, CountDownLatch latch, CountDownLatch messagesReceivedLatch, AtomicInteger disconnectCounter) {
+            super(uri);
+            onOpenLach = latch;
+            this.messagesReceivedLatch = messagesReceivedLatch;
+            this.disconnectCounter = disconnectCounter;
+        }
+
+        @Override
+        public void onOpen(ServerHandshake handshakedata) {
+            onOpenLach.countDown();
+        }
+
+        @Override
+        public void onMessage(String message) {
+        }
+
+        @Override
+        public void onMessage(ByteBuffer bytes) {
+            try {
+                // add some delay to message processing to simulate a slow consumer
+                Thread.sleep(1000);
+                messagesReceivedLatch.countDown();
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public void onClose(int code, String reason, boolean remote) {
+            log.error("Connection lost, code: {}, reason: {}, remote: {}", code, reason, remote);
+            disconnectCounter.incrementAndGet();
+        }
+
+        @Override
+        public void onError(Exception ex) {
+            log.error("Connection lost on error", ex);
+            disconnectCounter.incrementAndGet();
+        }
+    }
+
+}

--- a/src/test/java/org/java_websocket/server/ServerWriteBatchLimitTest.java
+++ b/src/test/java/org/java_websocket/server/ServerWriteBatchLimitTest.java
@@ -1,0 +1,159 @@
+package org.java_websocket.server;
+
+import org.java_websocket.WebSocket;
+import org.java_websocket.client.WebSocketClient;
+import org.java_websocket.handshake.ClientHandshake;
+import org.java_websocket.handshake.ServerHandshake;
+import org.java_websocket.util.SocketUtil;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Test improved ping/pongs for slow consumers.
+ */
+public class ServerWriteBatchLimitTest {
+
+    private static final Logger log = LoggerFactory.getLogger(ServerWriteBatchLimitTest.class);
+    private static final int numberOfMessagesSent = 100;
+    private static final int messageSizeInBytes = 1024;
+    private static final int maxBatchSize = 3 * 1024;
+
+
+    @Test
+    public void testMessageReceptionWithBatchLimit() throws Exception {
+        final CountDownLatch countServerStart = new CountDownLatch(1);
+        int port = SocketUtil.getAvailablePort();
+
+        AtomicInteger disconnectCounter = new AtomicInteger(0);
+
+        TestServer server = new TestServer(new InetSocketAddress(port), countServerStart, disconnectCounter);
+        server.setConnectionLostTimeout(100);
+        server.setMaxWriteBatchSizeInBytes(maxBatchSize);
+        server.start();
+        countServerStart.await(10, TimeUnit.SECONDS);
+
+        URI uri = new URI("ws://localhost:" + port);
+
+        CountDownLatch countClientConnectionDownLatch = new CountDownLatch(1);
+        CountDownLatch countReceivedMessagesDownLatch = new CountDownLatch(numberOfMessagesSent);
+        WebSocketClient client = new TestClient(uri,
+                countClientConnectionDownLatch,
+                countReceivedMessagesDownLatch,
+                disconnectCounter);
+        client.setConnectionLostTimeout(2);
+        client.connectBlocking();
+        countClientConnectionDownLatch.await(10, TimeUnit.SECONDS);
+
+        // send 10 messages in burst
+        server.startSending();
+
+        countReceivedMessagesDownLatch.await(15, TimeUnit.SECONDS);
+        Assertions.assertEquals(0, countReceivedMessagesDownLatch.getCount(), "Client did not receive all server messages.");
+    }
+
+
+    private static class TestServer extends  WebSocketServer {
+
+        private final CountDownLatch countServerStart;
+        private final AtomicInteger disconnectCounter;
+
+        private WebSocket clientConnection;
+
+        public TestServer(InetSocketAddress address, CountDownLatch countServerStart, AtomicInteger disconnectCounter) {
+            super(address);
+            this.countServerStart = countServerStart;
+            this.disconnectCounter = disconnectCounter;
+        }
+
+        @Override
+        public void onOpen(WebSocket conn, ClientHandshake handshake) {
+            clientConnection = conn;
+        }
+
+        @Override
+        public void onClose(WebSocket conn, int code, String reason, boolean remote) {
+            log.error("Connection lost, code: {}, reason: {}, remote: {}", code, reason, remote);
+            disconnectCounter.incrementAndGet();
+        }
+
+        @Override
+        public void onMessage(WebSocket conn, ByteBuffer message) {
+        }
+
+        @Override
+        public void onMessage(WebSocket conn, String message) {
+        }
+
+        @Override
+        public void onError(WebSocket conn, Exception ex) {
+            log.error("Connection lost on error", ex);
+            disconnectCounter.incrementAndGet();
+        }
+
+        @Override
+        public void onStart() {
+            countServerStart.countDown();
+        }
+
+        // burst send 10 messages
+        public void startSending() {
+            if (clientConnection == null)
+                throw new RuntimeException("No client connected");
+
+            byte[] msg = new byte[messageSizeInBytes];
+            for (int i = 0; i < numberOfMessagesSent; i++) {
+                clientConnection.send(msg);
+            }
+        }
+
+    }
+
+    static class TestClient extends WebSocketClient {
+        private final CountDownLatch onOpenLach;
+        private final CountDownLatch messagesReceivedLatch;
+        private final AtomicInteger disconnectCounter;
+
+        public TestClient(URI uri, CountDownLatch latch, CountDownLatch messagesReceivedLatch, AtomicInteger disconnectCounter) {
+            super(uri);
+            onOpenLach = latch;
+            this.messagesReceivedLatch = messagesReceivedLatch;
+            this.disconnectCounter = disconnectCounter;
+        }
+
+        @Override
+        public void onOpen(ServerHandshake handshakedata) {
+            onOpenLach.countDown();
+        }
+
+        @Override
+        public void onMessage(String message) {
+        }
+
+        @Override
+        public void onMessage(ByteBuffer bytes) {
+            messagesReceivedLatch.countDown();
+        }
+
+        @Override
+        public void onClose(int code, String reason, boolean remote) {
+            log.error("Connection lost, code: {}, reason: {}, remote: {}", code, reason, remote);
+            disconnectCounter.incrementAndGet();
+        }
+
+        @Override
+        public void onError(Exception ex) {
+            log.error("Connection lost on error", ex);
+            disconnectCounter.incrementAndGet();
+        }
+    }
+
+}


### PR DESCRIPTION
Contains three changes:

- Handle every received message as a pong to avoid heartbeat timeouts on data bursts
-- add a slow consumer test
- Add parameter maxWriteBatchSizeInBytes to WebSocketServer for write fairness in selectorThread
-- add write batch limit test
- Make webSocketImpl::flushandclosestate volotile to avoid NPE on data vsibility inconsistency

